### PR TITLE
Add new examples for gcloud

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,38 @@
+# https://github.com/Netflix/atlas/blob/301b4175459227b1f36de143464f3e23edf134a2/.scalafmt.conf
+version = 3.7.17
+runner.dialect = Scala213Source3
+
+style = defaultWithAlign
+
+align.openParenCallSite = false
+align.openParenDefnSite = false
+align.tokens = [{code = "->"}, {code = "<-"}, {code = "=>", owner = "Case"}]
+
+continuationIndent.callSite = 2
+continuationIndent.defnSite = 2
+
+danglingParentheses.preset = true
+
+docstrings.style = keep
+
+indentOperator = spray
+indentOperator.excludeRegex = "^(&&|\\|\\||~)$"
+indentOperator.exemptScope = all
+
+literals.hexDigits = Upper
+
+maxColumn = 100
+
+newlines.afterCurlyLambdaParams = keep
+newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
+newlines.inInterpolation = oneline
+newlines.topLevelBodyIfMinStatements = [before]
+newlines.topLevelStatementBlankLines = [
+  { blanks { before = 1, after = 0 } }
+]
+
+project.excludeFilters = [".*\\.sbt"]
+
+rewrite.rules = [RedundantParens, ExpandImportSelectors, AvoidInfix]
+
+spaces.inImportCurlyBraces = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 First release version of the project
 
 ### Added
+
 - support for gradle 7.6, java 11, spark 3.4.1, scala 2.12 and delta 2.4.0
 - support to read file:// and s3://
 - Added CHANGELOG.md
@@ -18,3 +19,14 @@ First release version of the project
 - Added tests for the above classes
 - Added scalaCodeCoverage
 - Added spotless, checkstyle, and spotbugs
+
+## [1.0.0] - 2023-02-03
+
+Run this application on Google Cloud Dataproc
+
+### Added
+
+- Added word count examples and test
+- Added GCS libraries and tests
+- Added abris
+- Added Hive sample app with public covid data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,5 +28,7 @@ Run this application on Google Cloud Dataproc
 
 - Added word count examples and test
 - Added GCS libraries and tests
-- Added abris
+- Added abris, an AVRO 3rd party library to read and write avro data
 - Added Hive sample app with public covid data
+- Removing delta dependency as GCP supports Iceberg
+- Added .scalafmt.conf file

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A Spark bootstrap project written in Scala with gradle as build tool.
 - JavaVersion=1.11
 - sparkVersion=3.4.1
 - scalaVersion=2.12
-- deltaVersion=2.4.0
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A Spark bootstrap project written in Scala with gradle as build tool.
 
 `java -version`
 
-    openjdk version "11.0.20" 2023-07-18
-    OpenJDK Runtime Environment Homebrew (build 11.0.20+0)
-    OpenJDK 64-Bit Server VM Homebrew (build 11.0.20+0, mixed mode)
+	openjdk version "11.0.20" 2023-07-18
+	OpenJDK Runtime Environment Homebrew (build 11.0.20+0)
+	OpenJDK 64-Bit Server VM Homebrew (build 11.0.20+0, mixed mode)
 
 `./gradlew clean build`
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ apply plugin: 'java'
 apply plugin: 'scala'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
-apply from: "$rootDir/gradle/artifactory.gradle"
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 apply from: "$rootDir/gradle/scoverage.gradle"
@@ -23,39 +22,51 @@ version version
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
-configurations {
-	provided
-}
-
-sourceSets {
-	main {
-		compileClasspath += configurations.provided
-	}
-}
-
 application {
 	mainClassName = 'dev.template.spark.Main'
 }
 
-
 repositories {
 	mavenCentral()
+	maven { url 'https://packages.confluent.io/maven/' }
+}
+configurations {
+	provided
+	sparkLib
 }
 
 dependencies {
-	implementation "org.scalameta:scalafmt-core_${scalaVersion}:${scalafmt}"
+	compileOnly "org.apache.spark:spark-core_${scalaVersion}:${sparkVersion}"
 	implementation "org.apache.spark:spark-sql_${scalaVersion}:${sparkVersion}"
-	implementation "org.apache.spark:spark-graphx_${scalaVersion}:${sparkVersion}"
-	implementation "org.apache.spark:spark-launcher_${scalaVersion}:${sparkVersion}"
-	implementation "org.apache.spark:spark-catalyst_${scalaVersion}:${sparkVersion}"
-	implementation "org.apache.spark:spark-streaming_${scalaVersion}:${sparkVersion}"
-	implementation "org.apache.spark:spark-core_${scalaVersion}:${sparkVersion}"
-
-	implementation "org.apache.hadoop:hadoop-aws:${hadoopAWS}"
-	implementation "org.apache.spark:spark-hive_${scalaVersion}:${sparkVersion}"
+	compileOnly "org.apache.spark:spark-graphx_${scalaVersion}:${sparkVersion}"
+	compileOnly "org.apache.spark:spark-launcher_${scalaVersion}:${sparkVersion}"
+	compileOnly "org.apache.spark:spark-catalyst_${scalaVersion}:${sparkVersion}"
+	compileOnly "org.apache.spark:spark-streaming_${scalaVersion}:${sparkVersion}"
+	compileOnly "za.co.absa:abris_${scalaVersion}:${abrisVersion}"
 	implementation "io.delta:delta-core_${scalaVersion}:${deltaVersion}"
-	compileOnly "org.scala-lang:scala-library:$scalaVersion"
-	compileOnly "org.scala-lang:scala-compiler:${scalaVersion}"
+
+	implementation "com.google.cloud.bigdataoss:gcs-connector:${gcsConnectorVersion}"
+	implementation("org.apache.kafka:kafka_${scalaVersion}:${kafkaClientVersion}") {
+		exclude group: 'io.confluent', module: 'kafka-schema-registry-client'
+	}
+	implementation "io.confluent:kafka-schema-registry-client:${confluentVersion}"
+
+	implementation "org.apache.spark:spark-hive_${scalaVersion}:${sparkVersion}"
+	implementation "org.apache.spark:spark-sql-kafka-0-10_${scalaVersion}:${kafkaClientVersion}"
+
+	provided "com.google.cloud.bigdataoss:gcs-connector:${gcsConnectorVersion}"
+	provided "org.scalameta:scalafmt-core_${scalaVersion}:${scalafmt}"
+	provided "org.apache.spark:spark-core_${scalaVersion}:${sparkVersion}"
+	provided "org.apache.spark:spark-sql_${scalaVersion}:${sparkVersion}"
+	provided "org.apache.spark:spark-avro_${scalaVersion}:${sparkVersion}"
+	provided "org.apache.spark:spark-sql-kafka-0-10_${scalaVersion}:${kafkaClientVersion}"
+	provided "za.co.absa:abris_${scalaVersion}:${abrisVersion}"
+	provided "org.apache.kafka:kafka_${scalaVersion}:${kafkaClientVersion}"
+	provided "io.confluent:kafka-schema-registry-client:${confluentVersion}"
+	provided "org.apache.hadoop:hadoop-aws:${hadoopAWS}"
+	provided "org.apache.spark:spark-hive_${scalaVersion}:${sparkVersion}"
+	provided "org.scala-lang:scala-library:$scalaVersion"
+	provided "org.scala-lang:scala-compiler:${scalaVersion}"
 
 	testImplementation "org.scalatestplus:junit-4-13_${scalaVersion}:3.2.2.0"
 	testImplementation "junit:junit:${junitVersion}"
@@ -65,7 +76,6 @@ dependencies {
 	testImplementation "org.junit.jupiter:junit-jupiter-api:${jupiterApi}"
 	testImplementation "org.scalatest:scalatest_${scalaVersion}:${scalaTests}"
 }
-
 
 jar {
 	classifier 'all'
@@ -79,6 +89,19 @@ jar {
 	zip64 true
 }
 
+sourceSets {
+	main.compileClasspath += configurations.provided
+	test.compileClasspath += configurations.provided
+	test.runtimeClasspath += configurations.provided
+	test.java.srcDirs = ['src/test/scala']
+
+	local {
+		main.compileClasspath += configurations.provided
+		compileClasspath += configurations.provided
+		runtimeClasspath += main.output
+		runtimeClasspath += configurations.provided
+	}
+}
 
 tasks.register('scalaTest', JavaExec) {
 	dependsOn['testClasses']
@@ -99,6 +122,6 @@ idea {
 
 task sparkSubmit(type: Exec) {
 	commandLine 'sh', '-c', "/Users/e1xx/spark-3.4.1-bin-hadoop3/bin/spark-submit " +
-			"--class dev.template.spark.RddCollect" +
+			"--class dev.template.spark.Wordcount" +
 			" --master spark://localhost:7077 build/libs/spark-scala-gradle-bootstrap-2.12.0-all.jar"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,10 @@ deltaVersion=2.4.0
 #kafka
 confluentVersion=7.5.0
 kafkaClientVersion=3.4.0
+#For confluent AVRO
+abrisVersion=6.3.0
+#GCS
+gcsConnectorVersion=hadoop3-2.2.19
 #logging
 slf4jVersion=1.7.21
 logbackVersion=1.1.7
@@ -20,7 +24,7 @@ junitVersion=4.13.2
 #project properties
 mainClassFile=dev.template.spark.Main
 title='apache-spark-framework'
-group='template.spark'
+group='dev.template.spark'
 version='1.0.0.SNAPSHOT'
 #gradle run time config
 org.gradle.jvmargs=-Xmx2048m

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -9,12 +9,12 @@ spotless {
 	}
 	scala {
 		version = "2.12.0"
-		scalafmt('3.5.9').configFile('.scalafmt.conf')
+		scalafmt('3.7.17').configFile('.scalafmt.conf')
 		trimTrailingWhitespace()
 		endWithNewline()
 	}
 	java {
-		googleJavaFormat('1.7')
+		googleJavaFormat('1.8')
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -205,6 +205,12 @@ set -- \
         org.gradle.wrapper.GradleWrapperMain \
         "$@"
 
+# Stop when "xargs" is not available.
+if ! command -v xargs >/dev/null 2>&1
+then
+    die "xargs is not available"
+fi
+
 # Use "xargs" to parse quoted args.
 #
 # With -n1 it outputs one arg per line, with the quotes and backslashes removed.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@
 @rem limitations under the License.
 @rem
 
-@if "%DEBUG%" == "" @echo off
+@if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
@@ -25,7 +25,7 @@
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
-if "%DIRNAME%" == "" set DIRNAME=.
+if "%DIRNAME%"=="" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -40,7 +40,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto execute
+if %ERRORLEVEL% equ 0 goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -75,13 +75,15 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if %ERRORLEVEL% equ 0 goto mainEnd
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal

--- a/src/main/scala/dev/template/spark/CovidDataHivePartitioner.scala
+++ b/src/main/scala/dev/template/spark/CovidDataHivePartitioner.scala
@@ -7,19 +7,24 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
 
-object CovidDataPartitioner
+object CovidDataHivePartitioner
     extends App
     with SparkSessionWrapper
     with Reader
     with Writer
     with Logger {
 
-  def writeParquet(spark: SparkSession, file: String, outputPath: String): Unit = {
+  def writeParquet(
+    spark: SparkSession,
+    file: String,
+    outputPath: String,
+    schema_location: String
+  ): Unit = {
     val covidData: Dataset[Row] = readCsv(spark).csv(file).repartition(1)
     log.info(covidData.printSchema())
     covidData.createOrReplaceTempView("covid")
 
-    val groupedView = sqlContext
+    val groupedView = spark.sqlContext
       .sql("""
              | select
              |  cast(to_date(date, "yyyy-MM-dd") as String) as reported_date,
@@ -32,10 +37,36 @@ object CovidDataPartitioner
              |""".stripMargin)
       .cache()
 
-    log.info(covidData.printSchema())
+    val createSchema = spark.sql(s""" create schema if not exists public_data
+                                    |LOCATION "$schema_location"
+                                    |""".stripMargin)
+    createSchema.show()
 
-    writeParquet(groupedView, outputPath, SaveMode.Overwrite, Some("reported_date"))
+    log.info(s"Schema Created ${createSchema.printSchema()}")
 
+    val tableCreated = spark.sql(s""" create external table if not exists public_data.covid
+                                    | (
+                                    | reported_date date,
+                                    | county string,
+                                    | state string,
+                                    | fips int,
+                                    | cases int,
+                                    | deaths int
+                                    |)
+                                    |  partitioned by (reported_date)
+                                    |  Stored as parquet
+                                    |LOCATION "$outputPath"
+                                    |""".stripMargin)
+
+    log.info(s"Table created $tableCreated.printSchema() ")
+
+    writeParquetAsTable(
+      groupedView,
+      SaveMode.Overwrite,
+      "poc.covid",
+      path = outputPath,
+      Some("reported_date")
+    )
   }
 
   if (args.length == 0) {
@@ -57,9 +88,10 @@ object CovidDataPartitioner
 
   val inputFilePath = args(0)
   val outputPath: String = args(1)
+  val hive_schema_path: String = args(2)
   log.info("Input path " + inputFilePath)
   log.info("Output path " + outputPath)
 
-  writeParquet(spark, inputFilePath, outputPath)
+  writeParquet(spark, inputFilePath, outputPath, hive_schema_path)
 
 }

--- a/src/main/scala/dev/template/spark/Logger.scala
+++ b/src/main/scala/dev/template/spark/Logger.scala
@@ -3,6 +3,7 @@ package dev.template.spark
 import org.apache.log4j
 
 trait Logger {
+
   @transient lazy val log: log4j.Logger =
     org.apache.log4j.LogManager.getLogger(getClass.getName)
 }

--- a/src/main/scala/dev/template/spark/Main.scala
+++ b/src/main/scala/dev/template/spark/Main.scala
@@ -3,11 +3,10 @@ package dev.template.spark
 import dev.template.spark.source.Reader
 import org.apache.spark.sql.functions.avg
 
-import java.io.File
-
 case class Person(firstName: String, lastName: String, country: String, age: Int)
 
 class CalculateAverageAge extends SparkSessionWrapper with Reader with Logger {
+
   def calculateAverageAge(file: String): Double = {
 
     import spark.implicits._
@@ -29,19 +28,20 @@ class CalculateAverageAge extends SparkSessionWrapper with Reader with Logger {
 }
 
 object Main extends App {
+
   if (args.length == 0) {
     println(""" USAGE :
-              | spark-submit \
-              | --class dev.template.spark.Main \
-              | --packages io.delta:delta-core_2.12:2.4.0 \
-              | --master spark://localhost:7077 \
-              | --deploy-mode client \
-              | --driver-memory 1g \
-              | --executor-memory 1g \
-              | --executor-cores 2 \
-              | build/libs/spark-scala-gradle-bootstrap-2.12.0-all.jar \
-              | src/main/resources/people-example.csv
-              |""".stripMargin)
+        | spark-submit \
+        | --class dev.template.spark.Main \
+        | --packages io.delta:delta-core_2.12:2.4.0 \
+        | --master spark://localhost:7077 \
+        | --deploy-mode client \
+        | --driver-memory 1g \
+        | --executor-memory 1g \
+        | --executor-cores 2 \
+        | build/libs/spark-scala-gradle-bootstrap-2.12.0-all.jar \
+        | src/main/resources/people-example.csv
+        |""".stripMargin)
     throw new RuntimeException("Requires input file people-example.csv")
   }
   private val inputFilePath = args(0)

--- a/src/main/scala/dev/template/spark/SparkSessionWrapper.scala
+++ b/src/main/scala/dev/template/spark/SparkSessionWrapper.scala
@@ -2,18 +2,26 @@ package dev.template.spark
 
 import org.apache.log4j.Level
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.{SQLContext, SparkSession}
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 
 trait SparkSessionWrapper extends Logger with AutoCloseable {
-  lazy val spark: SparkSession = SparkSession
+
+  lazy val spark = SparkSession
     .builder()
-    .appName("Spark example")
+    .appName("Spark CovidDataPartitioner example")
     .enableHiveSupport()
-    .config("spark.sql.warehouse.dir", "file:///tmp/spark-warehouse")
+    .config("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem")
+    .config("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS")
+    .config("fs.gs.auth.service.account.enable", "true")
+    .config("hive.metastore.warehouse.dir", "gs://<HIVE_WAREHOUSE_BUCKET>/hive-warehouse")
+    .config("spark.sql.warehouse.dir", "gs://<HIVE_WAREHOUSE_BUCKET>/spark-warehouse")
+    // For local testing
+    //    .config("spark.hadoop.google.cloud.auth.service.account.json.keyfile", "/path/to/key/keyfile.json")
     .config("spark.sql.parquet.enableVectorizedReader", "false")
-    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-    .config("spark.sql.catalog.spark_catalog",
-            "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    // hive
+    .config("spark.hadoop.hive.exec.dynamic.partition", "true")
+    .config("spark.hadoop.hive.exec.dynamic.partition.mode", "nonstrict")
     .getOrCreate()
 
   val sc: SparkContext = spark.sparkContext

--- a/src/main/scala/dev/template/spark/WordCount.scala
+++ b/src/main/scala/dev/template/spark/WordCount.scala
@@ -1,0 +1,68 @@
+package dev.template.spark
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
+
+//https://github.com/GoogleCloudPlatform/dataproc-scala-examples
+//https://cloud.google.com/sdk/gcloud/reference/dataproc/jobs/submit/spark
+object WordCount extends App {
+
+  val spark: SparkSession = SparkSession
+    .builder()
+    .appName("Spark WordCount example")
+    .enableHiveSupport()
+    //    .config("spark.sql.warehouse.dir", "file:///tmp/spark-warehouse/tables")
+    .config("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem")
+    .config("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS")
+    .config("fs.gs.auth.service.account.enable", "true")
+    .config("hive.metastore.warehouse.dir", "gs://<HIVE_WAREHOUSE_BUCKET>/hive-warehouse")
+    .config("spark.sql.parquet.enableVectorizedReader", "false")
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    .getOrCreate()
+
+  private val FS_GS_PROJECT_ID = "fs.gs.project.id"
+
+  private val FS_GS_SYSTEM_BUCKET = "fs.gs.system.bucket"
+
+  private val FS_GS_WORKING_DIR = "fs.gs.working.dir"
+
+  var sparkContext = spark.sparkContext
+
+  def executeWordCount(sparkContext: SparkContext, args: Array[String]): Unit = {
+
+    try {
+      if (args.length != 2) {
+        throw new IllegalArgumentException(
+          "Exactly 2 arguments are required: <inputPath> <outputPath>"
+        )
+      }
+      val inputPath = args(0)
+      val outputPath = args(1)
+
+      val conf = sparkContext.hadoopConfiguration
+      conf.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem")
+      conf.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS")
+      conf.set("fs.gs.auth.service.account.enable", "true")
+      val gcsOutputPath = new Path(String.format(outputPath, conf.get("fs.gs.system.bucket")))
+      val gcsFs = gcsOutputPath.getFileSystem(conf)
+
+      if (gcsFs.exists(gcsOutputPath) && !gcsFs.delete(gcsOutputPath, true)) {
+        System.err.println("Failed to delete the output directory: " + gcsOutputPath)
+      } else {
+        System.out.println("Delete the output bucket")
+      }
+
+      val lines = sparkContext.textFile(inputPath)
+      val words = lines.flatMap(line => line.split(" "))
+      val wordCounts = words.map(word => (word, 1)).reduceByKey(_ + _)
+      wordCounts.saveAsTextFile(outputPath)
+    } catch {
+      case e: Throwable => throw new RuntimeException(e)
+    }
+  }
+
+  executeWordCount(sparkContext, args)
+
+}

--- a/src/main/scala/dev/template/spark/sink/Writer.scala
+++ b/src/main/scala/dev/template/spark/sink/Writer.scala
@@ -1,14 +1,17 @@
 package dev.template.spark.sink
 
-import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SaveMode
 
 trait Writer {
-  def writeParquet(df: DataFrame,
-                   path: String,
-                   mode: SaveMode = SaveMode.Overwrite,
-                   partition: Option[String]): Unit = {
-    val dfWriter = df
-      .write
+
+  def writeParquet(
+    df: DataFrame,
+    path: String,
+    mode: SaveMode = SaveMode.Overwrite,
+    partition: Option[String]
+  ): Unit = {
+    val dfWriter = df.write
       .mode(mode)
     if (partition.isDefined) {
       dfWriter.partitionBy(partition.get)
@@ -16,13 +19,29 @@ trait Writer {
     dfWriter.save(path)
   }
 
-  def writeCsv(df: DataFrame,
-               path: String,
-               mode: SaveMode = SaveMode.Overwrite,
-               options: Map[String, String],
-               partition: Option[String]): Unit = {
-    val dfWriter = df
-      .write
+  def writeParquetAsTable(
+    df: DataFrame,
+    mode: SaveMode = SaveMode.Overwrite,
+    table: String,
+    path: String,
+    partition: Option[String]
+  ): Unit = {
+    val dfWriter = df.write.format("parquet").mode(mode)
+    if (partition.isDefined) {
+      dfWriter.partitionBy(partition.get)
+    }
+    dfWriter.options(Map("path" -> path)).saveAsTable(table)
+  }
+
+  def writeCsv(
+    df: DataFrame,
+    path: String,
+    mode: SaveMode = SaveMode.Overwrite,
+    options: Map[String, String] = Map("delimiter" -> ","),
+    partition: Option[String] = None
+  ): Unit = {
+    val dfWriter = df.write
+      .format("csv")
       .options(options)
       .mode(mode)
     if (partition.isDefined) {

--- a/src/main/scala/dev/template/spark/source/Reader.scala
+++ b/src/main/scala/dev/template/spark/source/Reader.scala
@@ -5,14 +5,12 @@ import org.apache.spark.sql.SparkSession
 trait Reader {
 
   def readCsv(spark: SparkSession) =
-    spark
-      .read
+    spark.read
       .option("header", true)
       .option("inferSchema", true)
       .option("mode", "DROPMALFORMED")
 
-  def readerCsvWithoutHeader(spark: SparkSession) = spark
-    .read
+  def readerCsvWithoutHeader(spark: SparkSession) = spark.read
     .option("header", false)
     .option("inferSchema", true)
     .option("mode", "DROPMALFORMED")
@@ -31,14 +29,10 @@ trait Reader {
    *   Kafka consumer properties
    * @return
    */
-  def readKafka(spark: SparkSession, topic: String, kafkaConfig: Map[String, String] = Map()) =
-    spark
-      .read
+  def readKafka(spark: SparkSession, kafkaConfig: Map[String, String] = Map()) =
+    spark.read
       .format("kafka")
       .options(kafkaConfig)
-      .option("subscribe", topic)
-      .option("startingOffsets", "earliest")
-      .option("endingOffsets", "latest")
       .load()
 
 }

--- a/src/test/resources/wordcount_intput.txt
+++ b/src/test/resources/wordcount_intput.txt
@@ -1,0 +1,4 @@
+﻿Language English
+Language Tamil
+Language Telugu
+Language German

--- a/src/test/scala/dev/template/spark/MainTest.scala
+++ b/src/test/scala/dev/template/spark/MainTest.scala
@@ -14,8 +14,10 @@ class MainTest extends AnyFunSpec with SparkSessionTestWrapper {
     it("calculates average age of the person data") {
       val file: URL =
         ClassLoader.getSystemClassLoader.getResource("people-example.csv")
-      assertEquals("23.0".toDouble,
-                   new CalculateAverageAge().calculateAverageAge(file.getFile).floor)
+      assertEquals(
+        "23.0".toDouble,
+        new CalculateAverageAge().calculateAverageAge(file.getFile).floor
+      )
     }
   }
 }

--- a/src/test/scala/dev/template/spark/SparkSessionTestWrapper.scala
+++ b/src/test/scala/dev/template/spark/SparkSessionTestWrapper.scala
@@ -4,11 +4,14 @@ import org.apache.spark.sql.SparkSession
 
 trait SparkSessionTestWrapper {
 
-  val spark = SparkSession
-    .builder
+  val spark = SparkSession.builder
     .master("local[*]")
     .config("spark.hadoop.hive.exec.dynamic.partition.mode", "nostrict")
+    .config("spark.sql.warehouse.dir", "file:///tmp/poc/spark-warehouse")
+    .config("spark.sql.parquet.enableVectorizedReader", "false")
     .config("hive.exec.dynamic.partition", "true")
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
     .enableHiveSupport()
     .getOrCreate()
+
 }

--- a/src/test/scala/dev/template/spark/WordCountTest.scala
+++ b/src/test/scala/dev/template/spark/WordCountTest.scala
@@ -1,0 +1,25 @@
+package dev.template.spark
+
+import org.junit.runner.RunWith
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WordCountTest extends AnyFunSpec with SparkSessionTestWrapper {
+
+  describe("WordCountTest") {
+    it("should executeWordCount") {
+
+      val input = ClassLoader.getSystemResource("wordcount_intput.txt").getFile
+      val output = ClassLoader.getSystemResource("").getFile + "/wordcount_output"
+
+      println(output)
+      println(input)
+      WordCount
+        .executeWordCount(sparkContext = spark.sparkContext, Array(input, output))
+
+      val lines = spark.sparkContext.textFile(output + "/part-*")
+      assert(lines.count() == 5)
+    }
+  }
+}


### PR DESCRIPTION

Run this application on Google Cloud Dataproc

### Added

- Added word count examples and test
- Added GCS libraries and tests
- Added abris, an AVRO 3rd party library to read and write avro data
- Added Hive sample app with public covid data
- Removing delta dependency as GCP supports Iceberg
- Added .scalafmt.conf file